### PR TITLE
SISRP-60590 - Rolls back OmniAuth to v1.9.1 to resolve error with /auth/cas redirect

### DIFF
--- a/lib/omniauth/cas/version.rb
+++ b/lib/omniauth/cas/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Cas
-    VERSION = '1.1.2'
+    VERSION = '1.1.3'
   end
 end

--- a/omniauth-cas.gemspec
+++ b/omniauth-cas.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Omniauth::Cas::VERSION
 
-  gem.add_dependency 'omniauth',                '~> 2.0.4'
+  gem.add_dependency 'omniauth',                '~> 1.9.1'
   gem.add_dependency 'nokogiri',                '~> 1.13.3'
   gem.add_dependency 'addressable',             '~> 2.8.0'
 


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/SISRP-60590