### PR TITLE
v1.1.4

### DIFF
--- a/lib/omniauth/cas/version.rb
+++ b/lib/omniauth/cas/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Cas
-    VERSION = '1.1.3'
+    VERSION = '1.1.4'
   end
 end

--- a/omniauth-cas.gemspec
+++ b/omniauth-cas.gemspec
@@ -15,14 +15,14 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Omniauth::Cas::VERSION
 
-  gem.add_dependency 'omniauth',                '~> 1.9.1'
-  gem.add_dependency 'nokogiri',                '~> 1.13.3'
-  gem.add_dependency 'addressable',             '~> 2.8.0'
+  gem.add_dependency 'omniauth',                '~> 2.1.0'
+  gem.add_dependency 'nokogiri',                '~> 1.13.8'
+  gem.add_dependency 'addressable',             '~> 2.8.1'
 
-  gem.add_development_dependency 'rake',        '~> 10.0'
-  gem.add_development_dependency 'webmock',     '~> 3.0.0'
-  gem.add_development_dependency 'rspec',       '~> 3.1.0'
-  gem.add_development_dependency 'rack-test',   '~> 0.6'
+  gem.add_development_dependency 'rake',        '~> 13.0.6'
+  gem.add_development_dependency 'webmock',     '~> 3.18.1'
+  gem.add_development_dependency 'rspec',       '~> 3.11.0'
+  gem.add_development_dependency 'rack-test',   '~> 0.8.3'
 
   gem.add_development_dependency 'awesome_print'
 end


### PR DESCRIPTION
Updates OmniAuth gem to v2.1.0 to resolve [CVE-2015-9284](https://nvd.nist.gov/vuln/detail/CVE-2015-9284).
Also updates other gem dependencies (Nokogiri, Addressable) to address other security advisories.

Does require that OmniAuth be configured to allow HTTP GET requests for the /auth/cas redirect.

```ruby
# config/initializers/omniauth.rb

# Add get request as allowed for OmniAuth redirect, disables warning
OmniAuth.config.allowed_request_methods.push(:get)
OmniAuth.config.silence_get_warning = true
```