### PR TITLE
Fix Nokogiri XPath Namespace Error in LogoutRequest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,23 +6,26 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Specs
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2']
-        experimental: [false]
+        ruby-version: ['3.0', '3.1', '3.2', '3.3', '3.4', '4.0']
+        channel: ['stable']
 
         include:
           - ruby-version: 'head'
-            experimental: true
+            channel: 'experimental'
 
-    continue-on-error: ${{ matrix.experimental }}
+    continue-on-error: ${{ matrix.channel != 'stable' }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/lib/omniauth/strategies/cas/logout_request.rb
+++ b/lib/omniauth/strategies/cas/logout_request.rb
@@ -31,8 +31,8 @@ module OmniAuth
         def logout_request
           @logout_request ||= begin
             saml = Nokogiri.parse(@request.params['logoutRequest'])
-            name_id = saml.xpath('//saml:NameID').text
-            sess_idx = saml.xpath('//samlp:SessionIndex').text
+            name_id = saml.xpath('//*[local-name()="NameID"]').text
+            sess_idx = saml.xpath('//*[local-name()="SessionIndex"]').text
             inject_params(name_id:name_id, session_index:sess_idx)
             @request
           end

--- a/spec/omniauth/strategies/cas/logout_request_spec.rb
+++ b/spec/omniauth/strategies/cas/logout_request_spec.rb
@@ -38,6 +38,21 @@ describe OmniAuth::Strategies::CAS::LogoutRequest do
       expect(@rack_input).to eq 'name_id=%40NOT_USED%40&session_index=ST-123456-123abc456def'
     end
 
+    context 'with different namespace prefixes' do
+      let(:logoutRequest) do
+        %Q[
+          <p:LogoutRequest xmlns:p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:a="urn:oasis:names:tc:SAML:2.0:assertion" ID="123abc-1234-ab12-cd34-1234abcd" Version="2.0" IssueInstant="#{Time.now.to_s}">
+            <a:NameID>user@example.com</a:NameID>
+            <p:SessionIndex>ST-987654-abcdef123456</p:SessionIndex>
+          </p:LogoutRequest>
+        ]
+      end
+
+      it 'still extracts NameID and SessionIndex correctly using local-name()' do
+        expect(@rack_input).to eq 'name_id=user%40example.com&session_index=ST-987654-abcdef123456'
+      end
+    end
+
     context 'that raise when parsed' do
       let(:env) { { 'rack.input' => nil } }
 


### PR DESCRIPTION
Have been receiving this error in our logs for a while when people logout:

```
(cas) Authentication failure! logout_request: Nokogiri::XML::XPath::SyntaxError, //saml:NameID: org.apache.xpath.domapi.XPathStylesheetDOM3Exception: Prefix must resolve to a namespace: saml
```

org.apache.xpath.domapi.XPathStylesheetDOM3Exception is a Java class from Apache Xalan, which is the XPath engine that Nokogiri uses under JRuby, instead of libxml2 on MRI Ruby. Neither Xalan nor libxml2 will automatically resolve document-declared namespace prefixes for you in XPath queries — you have to register them explicitly, or avoid them entirely with local-name().

The local-name() fix works on both runtimes for exactly that reason — it makes the XPath completely namespace-agnostic at evaluation time.